### PR TITLE
docs container: use focal as the base container

### DIFF
--- a/docker/Dockerfile_docs
+++ b/docker/Dockerfile_docs
@@ -2,7 +2,7 @@
 # PX4 docs build environment
 #
 
-FROM ubuntu:bionic
+FROM ubuntu:focal
 LABEL maintainer="Daniel Agar <daniel@agar.ca>"
 
 RUN apt-get update \


### PR DESCRIPTION
Currently failing with bionic: https://github.com/PX4/PX4-containers/runs/3001661210?check_suite_focus=true#step:5:1579. Trying focal. If it doesn't work, then we need to apply a direct fix to the ruby support.