### PR TITLE
Add ignition edifice for Ubuntu focal simulation environment

### DIFF
--- a/docker/Dockerfile_simulation-bionic
+++ b/docker/Dockerfile_simulation-bionic
@@ -23,6 +23,7 @@ RUN wget --quiet http://packages.osrfoundation.org/gazebo.key -O - | apt-key add
 		libopencv-dev \
 		libxml2-utils \
 		protobuf-compiler \
+		ignition-edifice \
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*

--- a/docker/Dockerfile_simulation-focal
+++ b/docker/Dockerfile_simulation-focal
@@ -27,6 +27,7 @@ RUN wget --quiet http://packages.osrfoundation.org/gazebo.key -O - | apt-key add
 		mesa-utils \
 		protobuf-compiler \
 		x-window-system \
+		ignition-edifice \
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*


### PR DESCRIPTION
**Problem Description**
This PR adds ignition edifice for Ubuntu focal simulation environment

Ignition Edifice is the LTS version for [ignition gazebo](https://ignitionrobotics.org/docs/edifice)

**Additional Context**
- This PR is needed for enabling firmware build tests in https://github.com/Auterion/px4-simulation-ignition/pull/12