### PR TITLE
Add pip install pynacl for security enabled targets (signing)

### DIFF
--- a/docker/Dockerfile_base-focal
+++ b/docker/Dockerfile_base-focal
@@ -64,7 +64,7 @@ RUN python3 -m pip install --upgrade pip wheel setuptools
 # Python 3 dependencies installed by pip
 RUN python3 -m pip install argparse argcomplete coverage cerberus empy jinja2 kconfiglib \
 		matplotlib==3.0.* numpy nunavut>=1.1.0 packaging pkgconfig pyros-genmsg pyulog \
-		pyyaml requests serial six toml psutil pyulog wheel jsonschema
+		pyyaml requests serial six toml psutil pyulog wheel jsonschema pynacl
 
 # manual ccache setup
 RUN ln -s /usr/bin/ccache /usr/lib/ccache/cc \


### PR DESCRIPTION
This adds pynacl for signing images

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>