### PR TITLE
Fix for nunavit version check and remove JSBSim deb

### DIFF
--- a/docker/Dockerfile_base-bionic
+++ b/docker/Dockerfile_base-bionic
@@ -63,7 +63,7 @@ RUN pip3 install wheel setuptools
 
 # Python 3 dependencies installed by pip
 RUN pip3 install argparse argcomplete coverage cerberus empy jinja2 kconfiglib \
-		matplotlib==3.0.* numpy nunavut>=1.1.0 packaging pkgconfig pyros-genmsg pyulog \
+		matplotlib==3.0.* numpy "nunavut>=1.1.0" packaging pkgconfig pyros-genmsg pyulog \
 		pyyaml requests serial six toml psutil pyulog wheel jsonschema
 
 # manual ccache setup

--- a/docker/Dockerfile_base-focal
+++ b/docker/Dockerfile_base-focal
@@ -63,7 +63,7 @@ RUN python3 -m pip install --upgrade pip wheel setuptools
 
 # Python 3 dependencies installed by pip
 RUN python3 -m pip install argparse argcomplete coverage cerberus empy jinja2 kconfiglib \
-		matplotlib==3.0.* numpy nunavut>=1.1.0 packaging pkgconfig pyros-genmsg pyulog \
+		matplotlib==3.0.* numpy "nunavut>=1.1.0" packaging pkgconfig pyros-genmsg pyulog \
 		pyyaml requests serial six toml psutil pyulog wheel jsonschema pynacl
 
 # manual ccache setup

--- a/docker/Dockerfile_simulation-bionic
+++ b/docker/Dockerfile_simulation-bionic
@@ -34,6 +34,11 @@ ENV QT_X11_NO_MITSHM 1
 # Use UTF8 encoding in java tools (needed to compile jMAVSim)
 ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 
+# so these can change at build time
+ARG JSBSIM_URL=https://github.com/JSBSim-Team/jsbsim/releases/download/v1.1.1a
+ARG	JSBSIM_DEB=JSBSim-devel_1.1.1-134.focal.amd64.deb
+
 # Install JSBSim
-RUN wget https://github.com/JSBSim-Team/jsbsim/releases/download/v1.1.1a/JSBSim-devel_1.1.1-134.bionic.amd64.deb
-RUN dpkg -i JSBSim-devel_1.1.1-134.bionic.amd64.deb
+RUN	wget "$JSBSIM_URL/$JSBSIM_DEB" && \
+	dpkg -i "$JSBSIM_DEB" && \
+	rm -f "$JSBSIM_DEB"

--- a/docker/Dockerfile_simulation-focal
+++ b/docker/Dockerfile_simulation-focal
@@ -38,6 +38,11 @@ ENV QT_X11_NO_MITSHM 1
 # Use UTF8 encoding in java tools (needed to compile jMAVSim)
 ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 
+# so these can change at build time
+ARG JSBSIM_URL=https://github.com/JSBSim-Team/jsbsim/releases/download/v1.1.1a
+ARG	JSBSIM_DEB=JSBSim-devel_1.1.1-134.focal.amd64.deb
+
 # Install JSBSim
-RUN wget https://github.com/JSBSim-Team/jsbsim/releases/download/v1.1.1a/JSBSim-devel_1.1.1-134.focal.amd64.deb
-RUN dpkg -i JSBSim-devel_1.1.1-134.focal.amd64.deb
+RUN	wget "$JSBSIM_URL/$JSBSIM_DEB" && \
+	dpkg -i "$JSBSIM_DEB" && \
+	rm -f "$JSBSIM_DEB"


### PR DESCRIPTION
In the focal and bionic base builds the pip install for nunavit wants an >=
installation. Because the > is a special character this should be quoted.

In the simulation builds for bionic and focal, the JSBSim file is downloaded
installed but the package is not deleted from root.

This fixes both
