### PR TITLE
bionic: add future-annotations python dependency

### DIFF
--- a/docker/Dockerfile_base-bionic
+++ b/docker/Dockerfile_base-bionic
@@ -64,7 +64,7 @@ RUN pip3 install wheel setuptools
 # Python 3 dependencies installed by pip
 RUN pip3 install argparse argcomplete coverage cerberus empy jinja2 kconfiglib \
 		matplotlib==3.0.* numpy nunavut>=1.1.0 packaging pkgconfig pyros-genmsg pyulog \
-		pyyaml requests serial six toml psutil pyulog wheel jsonschema
+		pyyaml requests serial six toml psutil pyulog wheel jsonschema future-annotations
 
 # manual ccache setup
 RUN ln -s /usr/bin/ccache /usr/lib/ccache/cc \


### PR DESCRIPTION
@dagar hopefully this fixes 3.6 support in my PR.