### PR TITLE
base: fix pip install quotation

### DIFF
--- a/docker/Dockerfile_base-bionic
+++ b/docker/Dockerfile_base-bionic
@@ -63,7 +63,7 @@ RUN pip3 install wheel setuptools
 
 # Python 3 dependencies installed by pip
 RUN pip3 install argparse argcomplete coverage cerberus empy jinja2 kconfiglib \
-		matplotlib==3.0.* numpy nunavut>=1.1.0 packaging pkgconfig pyros-genmsg pyulog \
+		matplotlib==3.0.* numpy "nunavut>=1.1.0" packaging pkgconfig pyros-genmsg pyulog \
 		pyyaml requests serial six toml psutil pyulog wheel jsonschema
 
 # manual ccache setup

--- a/docker/Dockerfile_base-focal
+++ b/docker/Dockerfile_base-focal
@@ -63,7 +63,7 @@ RUN python3 -m pip install --upgrade pip wheel setuptools
 
 # Python 3 dependencies installed by pip
 RUN python3 -m pip install argparse argcomplete coverage cerberus empy jinja2 kconfiglib \
-		matplotlib==3.0.* numpy nunavut>=1.1.0 packaging pkgconfig pyros-genmsg pyulog \
+		matplotlib==3.0.* numpy "nunavut>=1.1.0" packaging pkgconfig pyros-genmsg pyulog \
 		pyyaml requests serial six toml psutil pyulog wheel jsonschema pynacl
 
 # manual ccache setup


### PR DESCRIPTION
Pip installation version was not being quoted, causing ">=" to be
treated as a shell output redirect rather than a version.