### PR TITLE
Upgrade clang-tidy to v14 on Ubuntu 20.04

### DIFF
--- a/docker/Dockerfile_clang
+++ b/docker/Dockerfile_clang
@@ -3,32 +3,35 @@
 #  px4-dev-base + latest clang
 #
 
-FROM px4io/px4-dev-base-bionic:2021-09-08
+FROM px4io/px4-dev-base-focal:2022-08-12
 LABEL maintainer="Daniel Agar <daniel@agar.ca>"
 
 RUN wget --quiet http://apt.llvm.org/llvm-snapshot.gpg.key -O - | apt-key add - \
-	&& sh -c 'echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main" >> /etc/apt/sources.list' \
-	&& sh -c 'echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main" >> /etc/apt/sources.list' \
+	&& sh -c 'echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main" >> /etc/apt/sources.list' \
+	&& sh -c 'echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main" >> /etc/apt/sources.list' \
 	&& apt-get update \
 	&& DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
-		clang-6.0 \
-		clang-format-6.0 \
-		clang-tidy-6.0 \
-		lldb-6.0 \
-		llvm-6.0 \
+		clang-14 \
+		clang-format-14 \
+		clang-tidy-14 \
+		lldb-14 \
+		llvm-14 \
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 # clang-tidy version setup
-RUN	update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 1 \
-	&& update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-6.0 1 \
-	&& update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-6.0 1 \
-	&& update-alternatives --install /usr/bin/run-clang-tidy.py run-clang-tidy.py /usr/bin/run-clang-tidy-6.0.py 1 \
-	&& update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-6.0 1
+RUN	update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 1 \
+	&& update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-14 1 \
+	&& update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-14 1 \
+	&& update-alternatives --install /usr/bin/run-clang-tidy.py run-clang-tidy.py /usr/bin/run-clang-tidy-14.py 1 \
+	&& update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-14 1
 
 # manual ccache setup
 RUN	ln -s /usr/bin/ccache /usr/lib/ccache/clang \
 	&& ln -s /usr/bin/ccache /usr/lib/ccache/clang++
+
+# Link legacy Python to Python 3
+RUN ln -s /usr/bin/python3 /usr/bin/python
 
 ENV CCACHE_CPP2=1


### PR DESCRIPTION
I wanted to execute `make clang-tidy-quiet` on my local Ubuntu 22.04 machine, but it comes with clang-14 by default, which prints  additional error messages that are not caught by the CI, since it still uses clang-6.
This PR upgrades the docker container to clang-14 and add the additional configuration will be added in a PX4 PR once the docker container is ready.