### PR TITLE
nuttx: add ubuntu 22.04 and GCC 10.3

### DIFF
--- a/docker/Dockerfile_base-jammy
+++ b/docker/Dockerfile_base-jammy
@@ -1,0 +1,148 @@
+#
+# PX4 base development environment
+#
+
+FROM ubuntu:22.04
+LABEL maintainer="Ramon Roche <rroche@linuxfoundation.com>"
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+RUN apt-get update && apt-get -y --quiet --no-install-recommends install \
+    ant \
+    binutils-dev \
+		ca-certificates \
+		ccache \
+		cmake \
+		cppcheck \
+		curl \
+		dirmngr \
+		doxygen \
+		g++-multilib \
+		gcc-multilib \
+		gdb-multilib \
+    gettext \
+		git \
+		gnupg \
+		gosu \
+		lcov \
+    libelf-dev \
+		libexpat-dev \
+    libvecmath-java \
+		libfreetype6-dev \
+		libgmp-dev \
+		libgtest-dev \
+		libisl-dev \
+		libmpc-dev \
+		libmpfr-dev \
+		libpng-dev \
+		libssl-dev \
+		lsb-release \
+		make \
+		ninja-build \
+		openssh-client \
+    openjdk-11-jre \
+    openjdk-11-jdk \
+		python3-dev \
+		python3-pip \
+		rsync \
+    screen \
+		shellcheck \
+		tzdata \
+    texinfo \
+    u-boot-tools \
+    util-linux \
+		unzip \
+		valgrind \
+		wget \
+		xsltproc \
+		zip \
+	&& apt-get -y autoremove \
+	&& apt-get clean autoclean \
+	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+# Set java 11 as default
+sudo update-alternatives --set java $(update-alternatives --list java | grep "java-11")
+
+# gtest
+RUN cd /usr/src/gtest \
+	&& mkdir build && cd build \
+	&& cmake .. && make -j$(nproc) \
+	&& find . -name \*.a -exec cp {} /usr/lib \; \
+	&& cd .. && rm -rf build
+
+# Install Python 3 pip build dependencies first.
+RUN python3 -m pip install --upgrade pip wheel setuptools
+
+# Python 3 dependencies installed by pip
+RUN python3 -m pip install argparse argcomplete coverage cerberus empy jinja2 kconfiglib \
+		matplotlib==3.0.* numpy nunavut>=1.1.0 packaging pkgconfig pyros-genmsg pyulog \
+		pyyaml requests serial six toml psutil pyulog wheel jsonschema pynacl
+
+# manual ccache setup
+RUN ln -s /usr/bin/ccache /usr/lib/ccache/cc \
+	&& ln -s /usr/bin/ccache /usr/lib/ccache/c++
+
+# astyle v3.1
+RUN wget -q https://downloads.sourceforge.net/project/astyle/astyle/astyle%203.1/astyle_3.1_linux.tar.gz -O /tmp/astyle.tar.gz \
+	&& cd /tmp && tar zxf astyle.tar.gz && cd astyle/src \
+	&& make -f ../build/gcc/Makefile -j$(nproc) && cp bin/astyle /usr/local/bin \
+	&& rm -rf /tmp/*
+
+# Gradle (Required to build Fast-RTPS-Gen)
+#RUN wget -q "https://services.gradle.org/distributions/gradle-6.3-rc-4-bin.zip" -O /tmp/gradle-6.3-rc-4-bin.zip \
+	#&& mkdir /opt/gradle \
+	#&& cd /tmp \
+	#&& unzip -d /opt/gradle gradle-6.3-rc-4-bin.zip \
+	#&& rm -rf /tmp/*
+
+#ENV PATH "/opt/gradle/gradle-6.3-rc-4/bin:$PATH"
+
+# Intall foonathan_memory from source as it is required to Fast-RTPS >= 1.9
+#RUN git clone https://github.com/eProsima/foonathan_memory_vendor.git /tmp/foonathan_memory \
+	#&& cd /tmp/foonathan_memory \
+	#&& mkdir build && cd build \
+	#&& cmake .. \
+	#&& cmake --build . --target install -- -j $(nproc) \
+	#&& rm -rf /tmp/*
+
+# Fast-DDS (Fast-RTPS 2.0.2)
+#RUN git clone --recursive https://github.com/eProsima/Fast-DDS.git -b v2.0.2 /tmp/FastDDS-2.0.2 \
+	#&& cd /tmp/FastDDS-2.0.2 \
+	#&& mkdir build && cd build \
+	#&& cmake -DTHIRDPARTY=ON -DSECURITY=ON .. \
+	#&& cmake --build . --target install -- -j $(nproc) \
+	#&& rm -rf /tmp/*
+
+# Fast-RTPS-Gen 1.0.4
+#RUN git clone --recursive https://github.com/eProsima/Fast-DDS-Gen.git -b v1.0.4 /tmp/Fast-RTPS-Gen-1.0.4 \
+	#&& cd /tmp/Fast-RTPS-Gen-1.0.4 \
+	#&& gradle assemble \
+	#&& gradle install \
+	#&& rm -rf /tmp/*
+
+# create user with id 1001 (jenkins docker workflow default)
+RUN useradd --shell /bin/bash -u 1001 -c "" -m user && usermod -a -G dialout user
+
+# setup virtual X server
+RUN mkdir /tmp/.X11-unix && \
+	chmod 1777 /tmp/.X11-unix && \
+	chown -R root:root /tmp/.X11-unix
+ENV DISPLAY :99
+
+ENV CCACHE_UMASK=000
+ENV FASTRTPSGEN_DIR="/usr/local/bin/"
+ENV PATH="/usr/lib/ccache:$PATH"
+ENV TERM=xterm
+ENV TZ=UTC
+
+# SITL UDP PORTS
+EXPOSE 14556/udp
+EXPOSE 14557/udp
+
+# create and start as LOCAL_USER_ID
+COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+CMD ["/bin/bash"]

--- a/docker/Dockerfile_nuttx-jammy
+++ b/docker/Dockerfile_nuttx-jammy
@@ -1,0 +1,51 @@
+#
+# PX4 NuttX development environment in Ubuntu 20.04 Focal
+#
+
+FROM px4io/px4-dev-base-focal:2021-09-08
+LABEL maintainer="Daniel Agar <daniel@agar.ca>"
+
+RUN apt-get update \
+	&& DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
+		autoconf \
+		automake \
+		bison \
+		build-essential \
+		bzip2 \
+		file \
+		flex \
+		genromfs \
+		gperf \
+		libncurses5 \
+		libncurses5-dev \
+		libncursesw5-dev \
+		libtool \
+		pkg-config \
+		uncrustify \
+		vim-common \
+	&& apt-get -y autoremove \
+	&& apt-get clean autoclean \
+	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+# GNU Arm Embedded Toolchain: 10.3-2021.10 Released: October 21, 2021
+RUN mkdir -p /opt/gcc && cd /opt/gcc \
+	&& wget -qO- "https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2" | tar jx --strip 1 \
+	&& rm -rf /opt/gcc/share/doc
+
+ENV PATH="$PATH:/opt/gcc/bin"
+
+# manual ccache setup for arm-none-eabi-g++/arm-none-eabi-gcc
+RUN ln -s /usr/bin/ccache /usr/lib/ccache/arm-none-eabi-g++ \
+	&& ln -s /usr/bin/ccache /usr/lib/ccache/arm-none-eabi-gcc
+
+# nuttx tools
+RUN git clone --depth 1 https://bitbucket.org/nuttx/tools.git /tmp/tools \
+	&& cd /tmp/tools/kconfig-frontends \
+	&& autoreconf -f -i \
+	&& ./configure --enable-mconf --disable-nconf --disable-gconf --disable-qconf -prefix=/usr && make -j$(nproc) && make install \
+	&& rm -rf /tmp/*
+
+# bloaty - https://github.com/google/bloaty
+RUN git clone --recursive https://github.com/google/bloaty.git /tmp/bloaty \
+	&& cd /tmp/bloaty && cmake -GNinja . && ninja -j $(nproc) bloaty && cp bloaty /usr/local/bin/ \
+	&& rm -rf /tmp/*


### PR DESCRIPTION
My intention is to update PX4-Autopilot CI with this new image.

* Ubuntu 22.04 Jammy
* GCC 10.3 (Latest)

**Test FMUv5X build**

```
[1191/1193] Linking CXX executable px4_fmu-v5x_default.elf
Memory region         Used Size  Region Size  %age Used      FLASH_ITCM:          0 GB      2016 KB      0.00%
      FLASH_AXIM:     2026168 B      2016 KB     98.15%
        ITCM_RAM:          0 GB        16 KB      0.00%
        DTCM_RAM:          0 GB       128 KB      0.00%
           SRAM1:       92508 B       368 KB     24.55%
           SRAM2:          0 GB        16 KB      0.00%
```

**Test FMUv6X build**
```
[1124/1126] Linking CXX executable px4_fmu-v6x_default.elf
Memory region         Used Size  Region Size  %age Used
        ITCM_RAM:          0 GB        64 KB      0.00%
           FLASH:     1933892 B      1920 KB     98.36%
       DTCM1_RAM:          0 GB        64 KB      0.00%
       DTCM2_RAM:          0 GB        64 KB      0.00%
        AXI_SRAM:       99388 B       512 KB     18.96%
           SRAM1:          0 GB       128 KB      0.00%
           SRAM2:          0 GB       128 KB      0.00%
           SRAM3:          0 GB        32 KB      0.00%
           SRAM4:          2 KB        64 KB      3.12%
          BKPRAM:          0 GB         4 KB      0.00%
[1126/1126] Creating /Users/rroche/Work/Dronecode/PX4-Autopilot/build/px4_fmu-v6x_default/px4_fmu-v6x_default.px4
```