### PR TITLE
Install kitware cmake 3.25

### DIFF
--- a/docker/Dockerfile_aarch64
+++ b/docker/Dockerfile_aarch64
@@ -19,7 +19,6 @@ RUN apt-get update && apt-get -y --quiet --no-install-recommends install \
 		ccache \
 		clang \
 		clang-tidy \
-		cmake \
 		cppcheck \
 		curl \
 		default-jdk-headless \
@@ -57,6 +56,10 @@ RUN apt-get update && apt-get -y --quiet --no-install-recommends install \
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+# CMake 3.25
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.25.2/cmake-3.25.2-linux-x86_64.sh \
+	&& sh cmake-3.25.2-linux-x86_64.sh --prefix=/usr/local/ --exclude-subdir
 
 # Install Python 3 pip build dependencies first.
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10

--- a/docker/Dockerfile_base-bionic
+++ b/docker/Dockerfile_base-bionic
@@ -51,6 +51,14 @@ RUN apt-get update && apt-get -y --quiet --no-install-recommends install \
 	&& apt-get clean autoclean \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
+# CMake 3.25
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null \
+	&& echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null \
+	&& apt-get update \
+	&& apt-get -y --quiet --no-install-recommends install kitware-archive-keyring \
+	&& apt-get -y --quiet --no-install-recommends install cmake \
+	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
 # gtest
 RUN cd /usr/src/gtest \
 	&& mkdir build && cd build \


### PR DESCRIPTION
Use kitware ppa that distributes CMake 3.25 for Bionic.
Download kitware release of CMake 3.25 for aarch64 (Debian Buster)
Needed for px4/px4-autopilot#22017