### PR TITLE
Simulation image for Ubuntu Jammy

### DIFF
--- a/.github/workflows/docker_builds.yml
+++ b/.github/workflows/docker_builds.yml
@@ -77,6 +77,29 @@ jobs:
         tag_names: true
         workdir: docker
 
+  px4-dev-simulation-jammy:
+    name: "Ubuntu Jammy Simulation"
+    runs-on: ubuntu-latest
+    needs: px4-dev-base-jammy
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build container
+      if: github.event_name == 'pull_request'
+      run: |
+        cd docker
+        make px4-dev-simulation-jammy
+    - name: Build & Publish container
+      if: github.event_name == 'push' && (contains(github.ref, '/heads/master') || contains(github.ref, '/tags/'))
+      uses: julianoes/Publish-Docker-Github-Action@master
+      with:
+        name: px4io/px4-dev-simulation-jammy
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        dockerfile: Dockerfile_simulation-jammy
+        cache: false
+        tag_names: true
+        workdir: docker
+
   px4-dev-armhf:
     name: "Debian armhf"
     runs-on: ubuntu-latest

--- a/docker/Dockerfile_simulation-jammy
+++ b/docker/Dockerfile_simulation-jammy
@@ -1,0 +1,41 @@
+#
+# PX4 Gazebo 7 (Garden) development environment in Ubuntu 22.04 Focal
+#
+
+FROM px4io/px4-dev-base-jammy:latest
+LABEL maintainer="Nuno Marques <nuno.marques@dronesolutions.io>"
+
+RUN wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg \
+	&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null \
+	&& apt-get update \
+	&& DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
+		ant \
+		binutils \
+		bc \
+		dirmngr \
+		gz-garden \
+		gstreamer1.0-plugins-bad \
+		gstreamer1.0-plugins-base \
+		gstreamer1.0-plugins-good \
+		gstreamer1.0-plugins-ugly \
+		libeigen3-dev \
+		libgstreamer-plugins-base1.0-dev \
+		libimage-exiftool-perl \
+		libopencv-dev \
+		libxml2-utils \
+		mesa-utils \
+		protobuf-compiler \
+		x-window-system \
+	&& apt-get -y autoremove \
+	&& apt-get clean autoclean \
+	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+# Some QT-Apps/Gazebo don't not show controls without this
+ENV QT_X11_NO_MITSHM 1
+
+# Use UTF8 encoding in java tools (needed to compile jMAVSim)
+ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
+
+# Install JSBSim
+RUN wget https://github.com/JSBSim-Team/jsbsim/releases/download/v1.1.1a/JSBSim-devel_1.1.1-134.focal.amd64.deb
+RUN dpkg -i JSBSim-devel_1.1.1-134.focal.amd64.deb

--- a/docker/Dockerfile_simulation-jammy
+++ b/docker/Dockerfile_simulation-jammy
@@ -1,5 +1,5 @@
 #
-# PX4 Gazebo 7 (Garden) development environment in Ubuntu 22.04 Focal
+# PX4 Gazebo 7 (Garden) development environment in Ubuntu 22.04 Jammy
 #
 
 FROM px4io/px4-dev-base-jammy:latest

--- a/docker/Dockerfile_simulation-jammy
+++ b/docker/Dockerfile_simulation-jammy
@@ -3,7 +3,7 @@
 #
 
 FROM px4io/px4-dev-base-jammy:latest
-LABEL maintainer="Nuno Marques <nuno.marques@dronesolutions.io>"
+LABEL maintainer="Thomas Debrunner <thomas.debrunner@auterion.com>"
 
 RUN wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg \
 	&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -44,6 +44,9 @@ px4-dev-nuttx-focal: px4-dev-base-focal
 px4-dev-nuttx-jammy: px4-dev-base-jammy
 	docker build -t px4io/px4-dev-nuttx-jammy . -f Dockerfile_nuttx-jammy
 
+px4-dev-simulation-jammy: px4-dev-base-jammy
+	docker build -t px4io/px4-dev-simulation-jammy . -f Dockerfile_simulation-jammy
+
 px4-dev-nuttx-clang: px4-dev-clang
 	docker build -t px4io/px4-dev-nuttx-clang . -f Dockerfile_nuttx_clang
 


### PR DESCRIPTION
This adds a simulatio image for ubuntu jammy. Like the `ubuntu.sh` script, it installs Gazebo 7 (Garden).

