### PR TITLE
Fix empy version to 3.3.4

### DIFF
--- a/docker/Dockerfile_aarch64
+++ b/docker/Dockerfile_aarch64
@@ -63,7 +63,7 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 RUN pip3 install wheel setuptools
 
 # Python 3 dependencies installed by pip
-RUN pip3 install argparse argcomplete coverage cerberus empy jinja2 kconfiglib \
+RUN pip3 install argparse argcomplete coverage cerberus empy==3.3.4 jinja2 kconfiglib \
 		matplotlib==3.0.* numpy packaging pkgconfig pyros-genmsg pyulog \
 		pyyaml requests serial six toml psutil pyulog wheel jsonschema
 

--- a/docker/Dockerfile_armhf
+++ b/docker/Dockerfile_armhf
@@ -65,7 +65,7 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 RUN pip3 install wheel setuptools
 
 # Python 3 dependencies installed by pip
-RUN pip3 install argparse argcomplete coverage cerberus empy jinja2 kconfiglib \
+RUN pip3 install argparse argcomplete coverage cerberus empy==3.3.4 jinja2 kconfiglib \
 		matplotlib==3.0.* numpy packaging pkgconfig pyros-genmsg pyulog \
 		pyyaml requests serial six toml psutil pyulog wheel jsonschema
 

--- a/docker/Dockerfile_base-archlinux
+++ b/docker/Dockerfile_base-archlinux
@@ -30,7 +30,7 @@ RUN pacman -Sy --noconfirm \
 		zip
 
 # Python 3 dependencies installed by pip
-RUN pip3 install argparse argcomplete coverage cerberus empy jinja2 kconfiglib \
+RUN pip3 install argparse argcomplete coverage cerberus empy==3.3.4 jinja2 kconfiglib \
 		matplotlib==3.0.* numpy packaging pkgconfig pyros-genmsg pyulog \
 		pyyaml requests serial six toml psutil pyulog wheel jsonschema
 

--- a/docker/Dockerfile_base-bionic
+++ b/docker/Dockerfile_base-bionic
@@ -62,7 +62,7 @@ RUN cd /usr/src/gtest \
 RUN pip3 install wheel setuptools
 
 # Python 3 dependencies installed by pip
-RUN pip3 install argparse argcomplete coverage cerberus empy jinja2 kconfiglib \
+RUN pip3 install argparse argcomplete coverage cerberus empy==3.3.4 jinja2 kconfiglib \
 		matplotlib==3.0.* numpy nunavut>=1.1.0 packaging pkgconfig pyros-genmsg pyulog \
 		pyyaml requests serial six toml psutil pyulog wheel jsonschema
 

--- a/docker/Dockerfile_base-focal
+++ b/docker/Dockerfile_base-focal
@@ -62,7 +62,7 @@ RUN cd /usr/src/gtest \
 RUN python3 -m pip install --upgrade pip wheel setuptools
 
 # Python 3 dependencies installed by pip
-RUN python3 -m pip install argparse argcomplete coverage cerberus empy jinja2 kconfiglib \
+RUN python3 -m pip install argparse argcomplete coverage cerberus empy==3.3.4 jinja2 kconfiglib \
 		matplotlib==3.0.* numpy nunavut>=1.1.0 packaging pkgconfig pyros-genmsg pyulog \
 		pyyaml requests serial six toml psutil pyulog wheel jsonschema pynacl
 

--- a/docker/Dockerfile_base-jammy
+++ b/docker/Dockerfile_base-jammy
@@ -77,7 +77,7 @@ RUN cd /usr/src/gtest \
 RUN python3 -m pip install --upgrade pip wheel setuptools
 
 # Python 3 dependencies installed by pip
-RUN python3 -m pip install argparse argcomplete coverage cerberus empy jinja2 kconfiglib \
+RUN python3 -m pip install argparse argcomplete coverage cerberus empy==3.3.4 jinja2 kconfiglib \
     matplotlib>=3.0.* numpy nunavut>=1.1.0 packaging pkgconfig pyros-genmsg pyulog \
     pyyaml requests serial six toml psutil pyulog wheel jsonschema pynacl lxml
 

--- a/docker/Dockerfile_ros-melodic
+++ b/docker/Dockerfile_ros-melodic
@@ -46,7 +46,7 @@ RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" 
 RUN pip install wheel setuptools
 # FIXME: regression in control>0.8.4 (used by px4tools) does not run on Python 2.
 RUN pip install argcomplete argparse catkin_pkg catkin-tools cerberus coverage \
-    empy jinja2 matplotlib==2.2.* numpy pkgconfig control==0.8.4 px4tools pygments \
+    empy==3.3.4 jinja2 matplotlib==2.2.* numpy pkgconfig control==0.8.4 px4tools pygments \
     pymavlink packaging pyros-genmsg pyulog==0.8.0 pyyaml requests rosdep rospkg \
     serial six toml jsonschema==2.6.0
 


### PR DESCRIPTION
This fixes the empy version to 3.3.4 (like in https://github.com/PX4/PX4-Autopilot/pull/22466).

This is because empy released 4.x which is incompatible.