### PR TITLE
Dockerfile docs node18

### DIFF
--- a/docker/Dockerfile_docs
+++ b/docker/Dockerfile_docs
@@ -2,7 +2,7 @@
 # PX4 docs build environment
 #
 
-FROM ubuntu:focal
+FROM ubuntu:jammy
 LABEL maintainer="Daniel Agar <daniel@agar.ca>"
 
 RUN apt-get update \
@@ -12,8 +12,6 @@ RUN apt-get update \
 		git \
 		gosu \
 		libfontconfig \
-		npm \
-		nodejs \
 		ruby-dev \
 		zlib1g-dev \
 		curl \
@@ -24,26 +22,15 @@ RUN apt-get update \
 	&& apt-get clean autoclean \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
+# Install Node.js 18 and npm
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+	&& apt-get install -y nodejs
+
+# Install yarn
+RUN npm install --global yarn
+
 # Setup sources for getting yarn
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-
-RUN apt-get update \
-	&& DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
-		yarn \
-	&& apt-get -y autoremove \
-	&& apt-get clean autoclean \
-	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
-
-# Set up to install nodejs in version (12) required for worker scripts
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
-
-RUN apt-get update \
-	&& DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
-		nodejs \
-	&& apt-get -y autoremove \
-	&& apt-get clean autoclean \
-	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN gem install html-proofer
 
@@ -53,9 +40,6 @@ RUN useradd --shell /bin/bash -u 1001 -c "" -m user && usermod -a -G dialout use
 USER user
 ENV NPM_CONFIG_PREFIX=/home/user/.npm-global
 ENV PATH=$PATH:/home/user/.npm-global/bin
-
-RUN npm config set registry http://registry.npmjs.org/ \
-	&& npm install gitbook-cli -g --unsafe-perm=true
 
 ENV TERM=xterm
 ENV TZ=UTC

--- a/docker/Dockerfile_docs
+++ b/docker/Dockerfile_docs
@@ -29,9 +29,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
 # Install yarn
 RUN npm install --global yarn
 
-# Setup sources for getting yarn
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-
+# Install html-proofer
 RUN gem install html-proofer
 
 # create user with id 1001 (jenkins docker workflow default)


### PR DESCRIPTION
For vitepress I need Node 18. Might as well update to Jammy too. 

Note, I don't actually "want" to do this - but I can't get github actions to work for deployment to the docs.px4.io.