### PR TITLE
Install module "pyserial" instead of "serial"

### DIFF
--- a/docker/Dockerfile_base-archlinux
+++ b/docker/Dockerfile_base-archlinux
@@ -32,7 +32,7 @@ RUN pacman -Sy --noconfirm \
 # Python 3 dependencies installed by pip
 RUN pip3 install argparse argcomplete coverage cerberus empy==3.3.4 jinja2 kconfiglib \
 		matplotlib==3.0.* numpy packaging pkgconfig pyros-genmsg pyulog \
-		pyyaml requests pyserial six toml psutil pyulog wheel jsonschema
+		pyyaml requests pyserial six toml psutil pyulog wheel jsonschema future
 
 # Install genromfs
 RUN wget https://sourceforge.net/projects/romfs/files/genromfs/0.5.2/genromfs-0.5.2.tar.gz \

--- a/docker/Dockerfile_base-archlinux
+++ b/docker/Dockerfile_base-archlinux
@@ -32,7 +32,7 @@ RUN pacman -Sy --noconfirm \
 # Python 3 dependencies installed by pip
 RUN pip3 install argparse argcomplete coverage cerberus empy==3.3.4 jinja2 kconfiglib \
 		matplotlib==3.0.* numpy packaging pkgconfig pyros-genmsg pyulog \
-		pyyaml requests serial six toml psutil pyulog wheel jsonschema
+		pyyaml requests pyserial six toml psutil pyulog wheel jsonschema
 
 # Install genromfs
 RUN wget https://sourceforge.net/projects/romfs/files/genromfs/0.5.2/genromfs-0.5.2.tar.gz \

--- a/docker/Dockerfile_base-bionic
+++ b/docker/Dockerfile_base-bionic
@@ -64,7 +64,7 @@ RUN pip3 install wheel setuptools
 # Python 3 dependencies installed by pip
 RUN pip3 install argparse argcomplete coverage cerberus empy==3.3.4 jinja2 kconfiglib \
 		matplotlib==3.0.* numpy nunavut>=1.1.0 packaging pkgconfig pyros-genmsg pyulog \
-		pyyaml requests serial six toml psutil pyulog wheel jsonschema
+		pyyaml requests pyserial six toml psutil pyulog wheel jsonschema
 
 # manual ccache setup
 RUN ln -s /usr/bin/ccache /usr/lib/ccache/cc \

--- a/docker/Dockerfile_base-bionic
+++ b/docker/Dockerfile_base-bionic
@@ -64,7 +64,7 @@ RUN pip3 install wheel setuptools
 # Python 3 dependencies installed by pip
 RUN pip3 install argparse argcomplete coverage cerberus empy==3.3.4 jinja2 kconfiglib \
 		matplotlib==3.0.* numpy nunavut>=1.1.0 packaging pkgconfig pyros-genmsg pyulog \
-		pyyaml requests pyserial six toml psutil pyulog wheel jsonschema
+		pyyaml requests pyserial six toml psutil pyulog wheel jsonschema future
 
 # manual ccache setup
 RUN ln -s /usr/bin/ccache /usr/lib/ccache/cc \

--- a/docker/Dockerfile_base-focal
+++ b/docker/Dockerfile_base-focal
@@ -64,7 +64,7 @@ RUN python3 -m pip install --upgrade pip wheel setuptools
 # Python 3 dependencies installed by pip
 RUN python3 -m pip install argparse argcomplete coverage cerberus empy==3.3.4 jinja2 kconfiglib \
 		matplotlib==3.0.* numpy nunavut>=1.1.0 packaging pkgconfig pyros-genmsg pyulog \
-		pyyaml requests serial six toml psutil pyulog wheel jsonschema pynacl
+		pyyaml requests pyserial six toml psutil pyulog wheel jsonschema pynacl
 
 # manual ccache setup
 RUN ln -s /usr/bin/ccache /usr/lib/ccache/cc \

--- a/docker/Dockerfile_base-focal
+++ b/docker/Dockerfile_base-focal
@@ -64,7 +64,7 @@ RUN python3 -m pip install --upgrade pip wheel setuptools
 # Python 3 dependencies installed by pip
 RUN python3 -m pip install argparse argcomplete coverage cerberus empy==3.3.4 jinja2 kconfiglib \
 		matplotlib==3.0.* numpy nunavut>=1.1.0 packaging pkgconfig pyros-genmsg pyulog \
-		pyyaml requests pyserial six toml psutil pyulog wheel jsonschema pynacl
+		pyyaml requests pyserial six toml psutil pyulog wheel jsonschema pynacl future
 
 # manual ccache setup
 RUN ln -s /usr/bin/ccache /usr/lib/ccache/cc \

--- a/docker/Dockerfile_base-jammy
+++ b/docker/Dockerfile_base-jammy
@@ -79,7 +79,7 @@ RUN python3 -m pip install --upgrade pip wheel setuptools
 # Python 3 dependencies installed by pip
 RUN python3 -m pip install argparse argcomplete coverage cerberus empy==3.3.4 jinja2 kconfiglib \
     matplotlib>=3.0.* numpy nunavut>=1.1.0 packaging pkgconfig pyros-genmsg pyulog \
-    pyyaml requests serial six toml psutil pyulog wheel jsonschema pynacl lxml
+    pyyaml requests pyserial six toml psutil pyulog wheel jsonschema pynacl lxml
 
 #RUN python3 -m pip install argcomplete argparse>=1.2 cerberus coverage empy>=3.3 future \
   #jinja2>=2.8 jsonschema kconfiglib lxml matplotlib>=3.0.* numpy>=1.13 nunavut>=1.1.0 \

--- a/docker/Dockerfile_base-jammy
+++ b/docker/Dockerfile_base-jammy
@@ -79,7 +79,7 @@ RUN python3 -m pip install --upgrade pip wheel setuptools
 # Python 3 dependencies installed by pip
 RUN python3 -m pip install argparse argcomplete coverage cerberus empy==3.3.4 jinja2 kconfiglib \
     matplotlib>=3.0.* numpy nunavut>=1.1.0 packaging pkgconfig pyros-genmsg pyulog \
-    pyyaml requests pyserial six toml psutil pyulog wheel jsonschema pynacl lxml
+    pyyaml requests pyserial six toml psutil pyulog wheel jsonschema pynacl lxml future
 
 #RUN python3 -m pip install argcomplete argparse>=1.2 cerberus coverage empy>=3.3 future \
   #jinja2>=2.8 jsonschema kconfiglib lxml matplotlib>=3.0.* numpy>=1.13 nunavut>=1.1.0 \


### PR DESCRIPTION
I was trying to flash a Pixhawk v6x though the docker and even with appropriate rights, the upload python script was failing to connect to the board.

Digging a bit I got a reason: module 'serial' has no attribute 'Serial'

This is due to the fact that the module 'serial' is installed in the docker and not 'pyserial'. 

Is this wanted? do we need the module 'serial' or is it a typo mistake?

Anyway, without the module pyserial, the upload script won't work.

Thank you for your feedback.
