### PR TITLE
add python3-venv so that virtual environment work can be done

### DIFF
--- a/docker/Dockerfile_aarch64
+++ b/docker/Dockerfile_aarch64
@@ -47,6 +47,7 @@ RUN apt-get update && apt-get -y --quiet --no-install-recommends install \
 		pkg-config \
 		python3-dev \
 		python3-pip \
+		python3-venv \
 		rsync \
 		shellcheck \
 		tzdata \

--- a/docker/Dockerfile_armhf
+++ b/docker/Dockerfile_armhf
@@ -49,6 +49,7 @@ RUN apt-get update && apt-get -y --quiet --no-install-recommends install \
 		pkg-config \
 		python3-dev \
 		python3-pip \
+		python3-venv \
 		rsync \
 		shellcheck \
 		tzdata \

--- a/docker/Dockerfile_base-bionic
+++ b/docker/Dockerfile_base-bionic
@@ -39,6 +39,7 @@ RUN apt-get update && apt-get -y --quiet --no-install-recommends install \
 		pkg-config \
 		python3-dev \
 		python3-pip \
+		python3-venv \
 		rsync \
 		shellcheck \
 		tzdata \

--- a/docker/Dockerfile_base-focal
+++ b/docker/Dockerfile_base-focal
@@ -39,6 +39,7 @@ RUN apt-get update && apt-get -y --quiet --no-install-recommends install \
 		pkg-config \
 		python3-dev \
 		python3-pip \
+		python3-venv \
 		rsync \
 		shellcheck \
 		tzdata \

--- a/docker/Dockerfile_base-jammy
+++ b/docker/Dockerfile_base-jammy
@@ -47,6 +47,7 @@ RUN apt-get update && apt-get -y --quiet --no-install-recommends install \
 		python3 \
 		python3-dev \
 		python3-pip \
+		python3-venv \
 		rsync \
     screen \
 		shellcheck \


### PR DESCRIPTION
Hello, this pull request adds virtual environment support for the docker builds. This is necessary because newer versions of macos and ubuntu are using python3.12 by default and 3.12 blocks installation of pip dependencies using user level packages and require you to install all libraries using virtual environments. I'm currently working on a PR for this in https://github.com/PX4/PX4-Autopilot/pull/23228, but cannot progress past the CI/CD failures which depend on this package being available. 