### PR TITLE
Add symforce python dependency

### DIFF
--- a/docker/Dockerfile_aarch64
+++ b/docker/Dockerfile_aarch64
@@ -66,7 +66,7 @@ RUN pip3 install wheel setuptools
 # Python 3 dependencies installed by pip
 RUN pip3 install argparse argcomplete coverage cerberus empy==3.3.4 jinja2 kconfiglib \
 		matplotlib==3.0.* numpy packaging pkgconfig pyros-genmsg pyulog \
-		pyyaml requests serial six toml psutil pyulog wheel jsonschema
+		pyyaml requests serial six toml psutil pyulog wheel jsonschema symforce
 
 # astyle v3.1
 RUN wget -q https://downloads.sourceforge.net/project/astyle/astyle/astyle%203.1/astyle_3.1_linux.tar.gz -O /tmp/astyle.tar.gz \

--- a/docker/Dockerfile_base-archlinux
+++ b/docker/Dockerfile_base-archlinux
@@ -39,7 +39,7 @@ RUN pip3 install wheel setuptools
 # Python 3 dependencies installed by pip inside the virtual environment
 RUN pip3 install argparse argcomplete coverage cerberus empy==3.3.4 jinja2 \
 		kconfiglib matplotlib numpy packaging pkgconfig pyros-genmsg pyulog \
-		pyyaml requests serial six toml psutil pyulog wheel jsonschema
+		pyyaml requests serial six toml psutil pyulog wheel jsonschema symforce
 
 # Install genromfs
 RUN wget https://sourceforge.net/projects/romfs/files/genromfs/0.5.2/genromfs-0.5.2.tar.gz \

--- a/docker/Dockerfile_base-bionic
+++ b/docker/Dockerfile_base-bionic
@@ -65,7 +65,7 @@ RUN pip3 install wheel setuptools
 # Python 3 dependencies installed by pip
 RUN pip3 install argparse argcomplete coverage cerberus empy==3.3.4 jinja2 kconfiglib \
 		matplotlib==3.0.* numpy nunavut>=1.1.0 packaging pkgconfig pyros-genmsg pyulog \
-		pyyaml requests serial six toml psutil pyulog wheel jsonschema
+		pyyaml requests serial six toml psutil pyulog wheel jsonschema symforce
 
 # manual ccache setup
 RUN ln -s /usr/bin/ccache /usr/lib/ccache/cc \

--- a/docker/Dockerfile_base-focal
+++ b/docker/Dockerfile_base-focal
@@ -65,7 +65,7 @@ RUN python3 -m pip install --upgrade pip wheel setuptools
 # Python 3 dependencies installed by pip
 RUN python3 -m pip install argparse argcomplete coverage cerberus empy==3.3.4 jinja2 kconfiglib \
 		matplotlib==3.0.* numpy nunavut>=1.1.0 packaging pkgconfig pyros-genmsg pyulog \
-		pyyaml requests serial six toml psutil pyulog wheel jsonschema pynacl
+		pyyaml requests serial six toml psutil pyulog wheel jsonschema pynacl symforce
 
 # manual ccache setup
 RUN ln -s /usr/bin/ccache /usr/lib/ccache/cc \

--- a/docker/Dockerfile_base-jammy
+++ b/docker/Dockerfile_base-jammy
@@ -80,7 +80,7 @@ RUN python3 -m pip install --upgrade pip wheel setuptools
 # Python 3 dependencies installed by pip
 RUN python3 -m pip install argparse argcomplete coverage cerberus empy==3.3.4 jinja2 kconfiglib \
     matplotlib>=3.0.* numpy nunavut>=1.1.0 packaging pkgconfig pyros-genmsg pyulog \
-    pyyaml requests serial six toml psutil pyulog wheel jsonschema pynacl lxml
+    pyyaml requests serial six toml psutil pyulog wheel jsonschema pynacl lxml symforce
 
 #RUN python3 -m pip install argcomplete argparse>=1.2 cerberus coverage empy>=3.3 future \
   #jinja2>=2.8 jsonschema kconfiglib lxml matplotlib>=3.0.* numpy>=1.13 nunavut>=1.1.0 \


### PR DESCRIPTION
To fix this error I experienced during `make px4_sitl`:

```
-- cmake build type: RelWithDebInfo
-- ccache enabled via symlink (/usr/lib/ccache/c++ -> /usr/bin/ccache)
**/usr/bin/python3: Error while finding module specification for 'symforce.symbolic' (ModuleNotFoundError: No module named 'symforce')**
-- Could NOT find gz-transport (missing: gz-transport_DIR)
-- Found Java: /usr/bin/java (found version "1.8.0_292") 
-- ROMFS: ROMFS/px4fmu_common
Architecture:  amd64
```